### PR TITLE
Update solution configuration to not build UITests

### DIFF
--- a/XWeather/XWeather.sln
+++ b/XWeather/XWeather.sln
@@ -44,13 +44,10 @@ Global
 		{15ED7D76-DC89-4BE7-AF33-D5224EA24531}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{15ED7D76-DC89-4BE7-AF33-D5224EA24531}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{15ED7D76-DC89-4BE7-AF33-D5224EA24531}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{15ED7D76-DC89-4BE7-AF33-D5224EA24531}.Release|Any CPU.Build.0 = Release|Any CPU
 		{15ED7D76-DC89-4BE7-AF33-D5224EA24531}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
 		{15ED7D76-DC89-4BE7-AF33-D5224EA24531}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
 		{15ED7D76-DC89-4BE7-AF33-D5224EA24531}.Release|iPhone.ActiveCfg = Release|Any CPU
-		{15ED7D76-DC89-4BE7-AF33-D5224EA24531}.Release|iPhone.Build.0 = Release|Any CPU
 		{15ED7D76-DC89-4BE7-AF33-D5224EA24531}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
-		{15ED7D76-DC89-4BE7-AF33-D5224EA24531}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
 		{15ED7D76-DC89-4BE7-AF33-D5224EA24531}.Debug|iPhone.ActiveCfg = Debug|Any CPU
 		{15ED7D76-DC89-4BE7-AF33-D5224EA24531}.Debug|iPhone.Build.0 = Debug|Any CPU
 	EndGlobalSection


### PR DESCRIPTION
when in any Release configuration.

### Reason
When building the solution from command line in release config, it fails due to the UITest project not having an OutputDir defined [0]. To avoid the failure, don't build UITest in release config. 

[0] https://github.com/colbylwilliams/XWeather/blob/master/XWeather/UITests/XWeather.UITests.csproj